### PR TITLE
Add OTLP endpoint support for observability

### DIFF
--- a/observability/config.go
+++ b/observability/config.go
@@ -18,7 +18,10 @@ type Config struct {
 	TempoInsecure   bool
 	TempoSampleRate float64
 	OTLPEndpoint    string
-	OTLPTransport   string // grpc|http
+	// OTLPTransport selects the OTLP transport ("grpc" or "http").
+	// Default is "grpc" when empty. Value is case-insensitive.
+	// Note: current build supports gRPC only; "http" will return an error.
+	OTLPTransport string
 
 	// OTEL log batching (optional; zeros use sensible defaults)
 	LogBatchMaxQueueSize       int // e.g., 256 dev, 2048 prod

--- a/observability/config.go
+++ b/observability/config.go
@@ -17,6 +17,14 @@ type Config struct {
 	TempoEndpoint   string
 	TempoInsecure   bool
 	TempoSampleRate float64
+	OTLPEndpoint    string
+	OTLPTransport   string // grpc|http
+
+	// OTEL log batching (optional; zeros use sensible defaults)
+	LogBatchMaxQueueSize       int // e.g., 256 dev, 2048 prod
+	LogBatchMaxExportBatchSize int // e.g., 64 dev, 512 prod
+	LogBatchTimeoutSeconds     int // e.g., 2 dev, 5 prod
+	LogExportTimeoutSeconds    int // e.g., 3 dev, 10 prod
 }
 
 func (c Config) LokiEnabled() bool {
@@ -24,11 +32,11 @@ func (c Config) LokiEnabled() bool {
 }
 
 func (c Config) TracingEnabled() bool {
-	return c.TempoEndpoint != ""
+	return c.TempoEndpoint != "" || c.OTLPEndpoint != ""
 }
 
 func (c Config) MetricsEnabled() bool {
-	return c.MetricsAddress != ""
+	return c.MetricsAddress != "" || c.OTLPEndpoint != ""
 }
 
 func parseLogLevel(c Config) slog.Level {


### PR DESCRIPTION
Introduces OTLP endpoint and transport options to the Config struct, allowing metrics, tracing, and logging to use either the legacy endpoints or the new OTLP endpoint. Refactors provider setup functions to select the first available endpoint and disables metrics/tracing if none are configured.